### PR TITLE
fix: vacation day calculation

### DIFF
--- a/server/src/vacationDayCalculation.ts
+++ b/server/src/vacationDayCalculation.ts
@@ -22,9 +22,10 @@ async function getTotalVacationDays(user: User) {
 
         const contractDuration = (nextContractStartYear - contract.startYear) * 12 + nextContractStartMonth - contract.startMonth;
 
-        vacationDays += Math.ceil(contract.vacationDays * contractDuration / 12);
+        vacationDays += contract.vacationDays * contractDuration / 12
     }
 
+    vacationDays = Math.ceil(vacationDays);
     return vacationDays;
 
 }


### PR DESCRIPTION
Due to a rounding error, users could have a vacation day to much. This is now fixed